### PR TITLE
fix: correct OTel Drops episode day from Friday to Sunday

### DIFF
--- a/src/pages/podcast.astro
+++ b/src/pages/podcast.astro
@@ -395,7 +395,7 @@ import { seoData } from '../data/seo-data';
 							The OTel ecosystem ships constantly — new Collector releases, SDK updates, spec changes, semantic convention revisions. Keeping up manually is a full-time job.
 						</p>
 						<p class="text-white/60 text-lg leading-relaxed mb-8">
-							OTel Drops does the curation for you. Every Friday, a tight episode covering what actually moved — so you walk into the week informed.
+							OTel Drops does the curation for you. Every Sunday, a tight episode covering what actually moved — so you walk into the week informed.
 						</p>
 						<div class="space-y-4">
 							{[


### PR DESCRIPTION
## Summary
- Corrects the podcast page to state episodes release on Sundays instead of Fridays

## Test plan
- [ ] Verify the podcast page shows "Every Sunday" instead of "Every Friday"

🤖 Generated with [Claude Code](https://claude.com/claude-code)