### PR TITLE
fix(ci): use Node.js 22 to satisfy Astro 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
@@ -41,6 +46,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Astro 6 (bumped in abf4b11) requires Node >=22.12.0
- CI was using the runner default Node 20, causing `astro check` to fail
- Add `actions/setup-node@v4` with `node-version: '22'` to both jobs

## Test plan
- [ ] CI lint, type-check, build, and SEO validation jobs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)